### PR TITLE
micropython: update to be runnable on micropython

### DIFF
--- a/test_micro_umsgpack.py
+++ b/test_micro_umsgpack.py
@@ -1,0 +1,20 @@
+
+from umsgpack import loads, dumps
+
+def check_pack(d):
+    result = loads(dumps(d))
+    if result != d:
+        print("Error:\n  expected {}\n  got      {}".format(d, result))
+    assert result == d
+
+checks = [
+    list(range(10)),
+    [1, 'hi', [1,2,3], 42.5],
+    {"dict": 8899213, b'awesome': {"pi": 823432, "isfun": "yes"}},
+    {("tuple", b'keyed'): [1,2,3,"hi"], 42: "answer"},
+]
+
+for c in checks:
+    check_pack(c)
+
+print("umsgpack: tests passed")

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -51,9 +51,15 @@ version = (2,1)
 "Module version tuple"
 
 import struct
-import collections
 import sys
 import io
+
+def _ishashable(value):
+    try:
+        hash(value)
+        return True
+    except TypeError:
+        return False
 
 ################################################################################
 ### Ext Class
@@ -625,7 +631,7 @@ def _unpack_map(code, fp):
         if isinstance(k, list):
             # Attempt to convert list into a hashable tuple
             k = _deep_list_to_tuple(k)
-        elif not isinstance(k, collections.Hashable):
+        elif not _ishashable(k):
             raise UnhashableKeyException("encountered unhashable key: %s, %s" % (str(k), str(type(k))))
         elif k in d:
             raise DuplicateKeyException("encountered duplicate key: %s, %s" % (str(k), str(type(k))))
@@ -798,10 +804,13 @@ def __init():
     # Compatibility mode for handling strings/bytes with the old specification
     compatibility = False
 
-    # Auto-detect system float precision
-    if sys.float_info.mant_dig == 53:
-        _float_size = 64
-    else:
+    try:
+        # Auto-detect system float precision
+        if sys.float_info.mant_dig == 53:
+            _float_size = 64
+        else:
+            _float_size = 32
+    except AttributeError:  # micropython doesn't have sys.float_info
         _float_size = 32
 
     # Map packb and unpackb to the appropriate version


### PR DESCRIPTION
- to run on micropython,this depends on PR micropython/micropython-lib#29 and for the `io` module to be installed with `upip`