### PR TITLE
Support building universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = True

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name='u-msgpack-python',


### PR DESCRIPTION
You can build universal wheel by `python setup.py bdist_wheel`.
See also: https://packaging.python.org/en/latest/distributing/#universal-wheels