### PR TITLE
loads/unpackb should allow bytearray type

### DIFF
--- a/umsgpack.py
+++ b/umsgpack.py
@@ -713,14 +713,14 @@ def _unpackb2(s):
     Deserialize MessagePack bytes into a Python object.
 
     Args:
-        s: a 'str' containing serialized MessagePack bytes
+        s: a 'str' or 'bytearray' containing serialized MessagePack bytes
 
     Returns:
         A Python object.
 
     Raises:
         TypeError:
-            Packed data is not type 'str'.
+            Packed data is neither a 'str' nor a 'bytearray'.
         InsufficientDataException(UnpackException):
             Insufficient data to unpack the encoded object.
         InvalidStringException(UnpackException):
@@ -738,8 +738,8 @@ def _unpackb2(s):
     {u'compact': True, u'schema': 0}
     >>>
     """
-    if not isinstance(s, str):
-        raise TypeError("packed data is not type 'str'")
+    if not isinstance(s, (str, bytearray)):
+        raise TypeError("packed data must be type 'str' or 'bytearray'")
     return _unpack(io.BytesIO(s))
 
 # For Python 3, expects a bytes object

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -736,6 +736,8 @@ def _unpackb2(s):
     Example:
     >>> umsgpack.unpackb(b'\x82\xa7compact\xc3\xa6schema\x00')
     {u'compact': True, u'schema': 0}
+    >>> umsgpack.unpackb(bytearray(b'\x82\xa7compact\xc3\xa6schema\x00'))
+    {u'compact': True, u'schema': 0}
     >>>
     """
     if not isinstance(s, (str, bytearray)):


### PR DESCRIPTION
Some libraries (such as the haigha amqp library), ends up representing the packed byte sequence as a bytearray. This patch will allow the loads/unpackb method to accept this type as well as the str type.