### PR TITLE
Allow to hash extensions, thus allowing them as map keys.

### DIFF
--- a/umsgpack.py
+++ b/umsgpack.py
@@ -123,6 +123,13 @@ class Ext:
         s += ")"
         return s
 
+    def __hash__(self):
+        """
+        Allow to hash extensions, thus allowing them as map keys.
+        """
+        return self.type.__hash__() + self.data.__hash__()
+
+
 class InvalidString(bytes):
     """Subclass of bytes to hold invalid UTF-8 strings."""
     pass

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -127,7 +127,7 @@ class Ext:
         """
         Allow to hash extensions, thus allowing them as map keys.
         """
-        return self.type.__hash__() + self.data.__hash__()
+        return hash((self.type, self.data))
 
 
 class InvalidString(bytes):


### PR DESCRIPTION
Without this, you can't do:

```
umsgpack.dump({umsgpack.Ext(42, 'foo'): 'bar'})
```