### PR TITLE
test_umsgpack.py: fix test on big-endian platforms

### DIFF
--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -297,9 +297,9 @@ float_precision_test_vectors = [
 CustomType = namedtuple('CustomType', ['x', 'y', 'z'])
 
 ext_handlers = {
-    complex: lambda obj: umsgpack.Ext(0x20, struct.pack("ff", obj.real, obj.imag)),
+    complex: lambda obj: umsgpack.Ext(0x20, struct.pack("<ff", obj.real, obj.imag)),
     CustomType: lambda obj: umsgpack.Ext(0x30, umsgpack.packb(list(obj))),
-    0x20: lambda ext: complex(*struct.unpack("ff", ext.data)),
+    0x20: lambda ext: complex(*struct.unpack("<ff", ext.data)),
     0x30: lambda ext: CustomType(*umsgpack.unpackb(ext.data)),
 }
 


### PR DESCRIPTION
On powerpc and powerpc64 one test fails as:

```
  $ py.test -v
  ...
  test_umsgpack.py::TestUmsgpack::test_pack_ext_handler FAILED
  test_umsgpack.py::TestUmsgpack::test_unpack_ext_handler FAILED
  ...

  self = <test_umsgpack.TestUmsgpack testMethod=test_pack_ext_handler>

    def test_pack_ext_handler(self):
        for (name, obj, data) in ext_handlers_test_vectors:
            obj_repr = repr(obj)
            print("\tTesting %s: object %s" %
                  (name, obj_repr if len(obj_repr) < 24 else obj_repr[0:24] + "..."))
            packed = umsgpack.packb(obj, ext_handlers=ext_handlers)
  >           self.assertEqual(packed, data)
  E           AssertionError: b'\xd7 ?\x80\x00\x00@\x00\x00\x00' != b'\xd7 \x00\x00\x80?\x00\x00\x00@'

  test_umsgpack.py:484: AssertionError
```

The problem here is in 'struct.pack' output:
it uses native endianness format but test hardcodes little-endian output.

The change forces 'struct.pack' into little-endian format.
That way all tests pass:.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>