### PR TITLE
Inherit from object, to allow for clean python2 inheritence

### DIFF
--- a/umsgpack.py
+++ b/umsgpack.py
@@ -61,7 +61,7 @@ version = (2, 5, 0)
 ##############################################################################
 
 # Extension type for application-defined types and data
-class Ext:
+class Ext(object):
     """
     The Ext class facilitates creating a serializable extension object to store
     an application-defined type and data byte array.


### PR DESCRIPTION
This allows people to inherit from Ext in python2. Currently you get error messages like `TypeError: super() argument 1 must be type, not classobj` if you try to follow good practices while doing so.