### PR TITLE
Allow for easier construction of serializable objects

### DIFF
--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -585,20 +585,20 @@ class TestUmsgpack(unittest.TestCase):
             def _unpackb(cls, ext):
                 return cls()
             
-        self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
+        self.assertTrue(isinstance(umsgpack.unpackb(umsgpack.packb(Stub())), Stub))
         
     def test_ext_namedtuple_inheritor(self):
         class Stub(umsgpack.Ext, namedtuple('_Stub', ['foo'])):
             type = 2
                    
             def __init__(self, *args, **kwargs):
-                super(Stub, self).__init__(Stub.type, msgpack.packb(tuple(self)))
+                super(Stub, self).__init__(Stub.type, umsgpack.packb(tuple(self)))
            
             @classmethod
             def _unpackb(cls, ext):
-                return cls(*msgpack.unpackb(ext.data))
+                return cls(*umsgpack.unpackb(ext.data))
             
-        self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub))
+        self.assertTrue(isinstance(umsgpack.unpackb(umsgpack.packb(Stub(1))), Stub))
 
     def test_namespacing(self):
         # Get a list of global variables from umsgpack module

--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -577,6 +577,9 @@ class TestUmsgpack(unittest.TestCase):
         class Stub(umsgpack.Ext):
             type = 1
             
+            def __init__(self):
+                pass
+            
             @property
             def data(self):
                 return umsgpack.packb(None)

--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -353,6 +353,7 @@ override_ext_handlers_test_vectors = [
 # These are the only global variables that should be exported by umsgpack
 exported_vars_test_vector = [
     "Ext",
+    "ExtType",
     "InvalidString",
     "PackException",
     "UnpackException",
@@ -572,35 +573,35 @@ class TestUmsgpack(unittest.TestCase):
         (_, obj, data) = composite_test_vectors[0]
         reader = io.BytesIO(data)
         self.assertEqual(umsgpack.unpack(reader), obj)
-        
+
     def test_ext_inheritor(self):
         class Stub(umsgpack.Ext):
             type = 1
-            
+
             def __init__(self):
                 pass
-            
+
             @property
             def data(self):
                 return umsgpack.packb(None)
-           
+
             @classmethod
             def _unpackb(cls, ext):
                 return cls()
-            
+
         self.assertTrue(isinstance(umsgpack.unpackb(umsgpack.packb(Stub())), Stub))
-        
+
     def test_ext_namedtuple_inheritor(self):
         class Stub(umsgpack.Ext, namedtuple('_Stub', ['foo'])):
             type = 2
-                   
+
             def __init__(self, *args, **kwargs):
                 super(Stub, self).__init__(Stub.type, umsgpack.packb(tuple(self)))
-           
+
             @classmethod
             def _unpackb(cls, ext):
                 return cls(*umsgpack.unpackb(ext.data))
-            
+
         self.assertTrue(isinstance(umsgpack.unpackb(umsgpack.packb(Stub(1))), Stub))
 
     def test_namespacing(self):

--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -579,7 +579,7 @@ class TestUmsgpack(unittest.TestCase):
                                     dir(umsgpack)))
         # Ignore imports
         exported_vars = list(filter(lambda x: x != "struct" and x != "collections" and x != "datetime" and x !=
-                                    "sys" and x != "io" and x != "xrange", exported_vars))
+                                    "sys" and x != "io" and x != "xrange" and x != "itertools", exported_vars))
 
         self.assertTrue(len(exported_vars) == len(exported_vars_test_vector))
         for var in exported_vars_test_vector:

--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -588,7 +588,7 @@ class TestUmsgpack(unittest.TestCase):
         selt.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
         
     def test_ext_namedtuple_inheritor(self):
-        class Stub(umsgpack.Ext, namedtuple('_Stub', ['foo']):
+        class Stub(umsgpack.Ext, namedtuple('_Stub', ['foo'])):
             type = 2
                    
             def __init__(self, *args, **kwargs):
@@ -598,7 +598,7 @@ class TestUmsgpack(unittest.TestCase):
             def _unpackb(cls, ext):
                 return cls(*msgpack.unpackb(ext.data))
             
-        selt.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
+        selt.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub))
 
     def test_namespacing(self):
         # Get a list of global variables from umsgpack module

--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -585,7 +585,7 @@ class TestUmsgpack(unittest.TestCase):
             def _unpackb(cls, ext):
                 return cls()
             
-        selt.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
+        self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub())), Stub))
         
     def test_ext_namedtuple_inheritor(self):
         class Stub(umsgpack.Ext, namedtuple('_Stub', ['foo'])):
@@ -598,7 +598,7 @@ class TestUmsgpack(unittest.TestCase):
             def _unpackb(cls, ext):
                 return cls(*msgpack.unpackb(ext.data))
             
-        selt.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub))
+        self.assertTrue(isinstance(msgpack.unpackb(msgpack.packb(Stub(1))), Stub))
 
     def test_namespacing(self):
         # Get a list of global variables from umsgpack module

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -61,7 +61,7 @@ version = (2, 5, 0)
 ##############################################################################
 
 # Extension type for application-defined types and data
-class Ext:
+class Ext(object):
     """
     The Ext class facilitates creating a serializable extension object to store
     an application-defined type and data byte array.
@@ -449,14 +449,14 @@ def _pack2(obj, fp, **options):
         _pack_string(obj, fp, options)
     elif isinstance(obj, str):
         _pack_binary(obj, fp, options)
+    elif isinstance(obj, Ext):
+        _pack_ext(obj, fp, options)
     elif isinstance(obj, list) or isinstance(obj, tuple):
         _pack_array(obj, fp, options)
     elif isinstance(obj, dict):
         _pack_map(obj, fp, options)
     elif isinstance(obj, datetime.datetime):
         _pack_ext_timestamp(obj, fp, options)
-    elif isinstance(obj, Ext):
-        _pack_ext(obj, fp, options)
     elif ext_handlers:
         # Linear search for superclass
         t = next((t for t in ext_handlers.keys() if isinstance(obj, t)), None)
@@ -521,14 +521,14 @@ def _pack3(obj, fp, **options):
         _pack_string(obj, fp, options)
     elif isinstance(obj, bytes):
         _pack_binary(obj, fp, options)
+    elif isinstance(obj, Ext):
+        _pack_ext(obj, fp, options)
     elif isinstance(obj, list) or isinstance(obj, tuple):
         _pack_array(obj, fp, options)
     elif isinstance(obj, dict):
         _pack_map(obj, fp, options)
     elif isinstance(obj, datetime.datetime):
         _pack_ext_timestamp(obj, fp, options)
-    elif isinstance(obj, Ext):
-        _pack_ext(obj, fp, options)
     elif ext_handlers:
         # Linear search for superclass
         t = next((t for t in ext_handlers.keys() if isinstance(obj, t)), None)

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -868,7 +868,10 @@ def _unpack_map(code, fp, options):
 
 def _unpack(fp, options):
     getter = lambda x: getattr(x, 'type', getattr(x, 'code', float('NaN')))
-    auto_handlers = {getter(x): x._unpackb for x in _subclasses(Ext)}
+    auto_handlers = {}
+    for x in _subclasses(Ext):
+        if x.type not in auto_handlers:
+            auto_handlers[x.type] = x._unpackb
     if 'ext_handlers' in options:
         auto_handlers.update(options['ext_handlers'])
     options['ext_handlers'] = auto_handlers

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -148,7 +148,8 @@ def subclasses(cls, unique=True):
     class.__subclasses__(), this returns all subclasses, not just direct ones.
     Note: though issubclass(cls, cls) returns True, we do not yield cls"""
     if unique:
-        return filter_unique(subclasses(cls, unique=False))
+        for x in filter_unique(subclasses(cls, unique=False)):
+            yield x
     else:
         sub = tuple(x for x in cls.__subclasses__() if x is not type)
         for x in sub:

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -133,8 +133,11 @@ class Ext(object):
         Provide a hash of this Ext object.
         """
         return hash((self.type, self.data))
-    
-    
+
+
+ExtType = Ext  # alias for msgpack-python compatibility
+
+
 #############################################################################
 # Autodetect subclasses of Ext
 #############################################################################
@@ -864,10 +867,11 @@ def _unpack_map(code, fp, options):
 
 
 def _unpack(fp, options):
-    auto_handlers = {x.type: x._unpackb for x in _subclasses(Ext)}
+    getter = lambda x: getattr(x, 'type', getattr(x, 'code', float('NaN')))
+    auto_handlers = {getter(x): x._unpackb for x in _subclasses(Ext)}
     if 'ext_handlers' in options:
         auto_handlers.update(options['ext_handlers'])
-    options['ext_handlers'] = auto_handlers        
+    options['ext_handlers'] = auto_handlers
     code = _read_except(fp, 1)
     return _unpack_dispatch_table[code](code, fp, options)
 

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -870,8 +870,8 @@ def _unpack(fp, options):
     getter = lambda x: getattr(x, 'type', getattr(x, 'code', float('NaN')))
     auto_handlers = {}
     for x in _subclasses(Ext):
-        if x.type not in auto_handlers:
-            auto_handlers[x.type] = x._unpackb
+        if getter(x) not in auto_handlers:
+            auto_handlers[getter(x)] = x._unpackb
     if 'ext_handlers' in options:
         auto_handlers.update(options['ext_handlers'])
     options['ext_handlers'] = auto_handlers


### PR DESCRIPTION
This PR adds the ability to usefully inherit from Ext. It changes four things:

1. Serializes Ext before tuple, to enable inheritance from both NamedTuple and Ext
2. Ensures that Ext inherits from object, so that we can detect its subclasses
3. Detects subclasses of Ext at unpack time, so that these classes do not need ext_handlers
4. Makes ExtType an alias for Ext to mirror msgpack-python API

In python3, you can have the pretty NamedTuple version by inheriting from an initially defined class. In python2, you can inherit from a function call to namedtuple(). In both cases, all that needs to happen is for the class to define a `type`/`code` variable, to define a `data` variable/property, and to define an `_unpackb` method for umsgpack to hook onto.

This PR enables the following in Python 3

```python
from typing import NamedTuple
from umsgpack import Ext, packb, unpackb


class _Serializable3(NamedTuple):
    foo: str
    bar: int


class Serializable3(Ext, _Serializable3):
    type = 1

    def __init__(self, *args, **kwargs):
        super().__init__(Serializable3.type, packb(self[:]))

    @classmethod
    def _unpackb(cls, ext: Ext) -> 'Serializable3':
        return cls(*unpackb(ext.data))


class Serializable3Alt(Ext, NamedTuple('_Serializable3Alt', [('foo', str), ('bar', int)])):
    type = 2

    def __init__(self, *args, **kwargs):
        super().__init__(Serializable3Alt.type, packb(self[:]))

    @classmethod
    def _unpackb(cls, ext: Ext) -> 'Serializable3Alt':
        return cls(*unpackb(ext.data))
```

And the following in Python 2 or 3:

```python
from collections import namedtuple
from umsgpack import Ext, packb, unpackb


class Serializable2(Ext, namedtuple('_Serializable2', ['foo', 'bar'])):
    type = 3

    def __init__(self, *args, **kwargs):
        super(Serializable2, self).__init__(Serializable2.type, packb(self[:]))

    @classmethod
    def _unpackb(cls, ext):
        return cls(*unpackb(ext.data))
```

This also enables for more flexible serialization through the use of dynamically calculated data:

```python
from umsgpack import Ext, packb, unpackb


class SerializableStub(Ext):
    type = 4

    def __init__(self, foo):
        self.foo = foo
        # note that Ext is not initialized for this style

    @property
    def data(self):
        return packb((self.foo, ))

    @classmethod
    def _unpackb(cls, ext):
        return cls(*unpackb(ext.data))
```