### PR TITLE
Solve DeprecationWarning

### DIFF
--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -608,8 +608,8 @@ class TestUmsgpack(unittest.TestCase):
         exported_vars = list(filter(lambda x: not x.startswith("_"),
                                     dir(umsgpack)))
         # Ignore imports
-        exported_vars = list(filter(lambda x: x != "struct" and x != "collections" and x != "datetime" and x !=
-                                    "sys" and x != "io" and x != "xrange", exported_vars))
+        exported_vars = list(filter(lambda x: x not in ("struct", "Hashable", "datetime", "version_info", "float_info",
+                                                        "Bytes", "xrange", "OrderedDict"), exported_vars))
 
         self.assertTrue(len(exported_vars) == len(exported_vars_test_vector))
         for var in exported_vars_test_vector:

--- a/test_umsgpack.py
+++ b/test_umsgpack.py
@@ -609,7 +609,7 @@ class TestUmsgpack(unittest.TestCase):
                                     dir(umsgpack)))
         # Ignore imports
         exported_vars = list(filter(lambda x: x not in ("struct", "Hashable", "datetime", "version_info", "float_info",
-                                                        "Bytes", "xrange", "OrderedDict"), exported_vars))
+                                                        "BytesIO", "xrange", "OrderedDict"), exported_vars))
 
         self.assertTrue(len(exported_vars) == len(exported_vars_test_vector))
         for var in exported_vars_test_vector:


### PR DESCRIPTION
Running tests on Python 3.7 I get the following warning:

`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`

While I was there I migrated some other imports to "from foo import bar", where it was easy to do so and there was no version conflicts.