### PR TITLE
Support more complicated inheritance schemes

### DIFF
--- a/umsgpack.py
+++ b/umsgpack.py
@@ -161,7 +161,7 @@ def ext_serializable(ext_type):
     """
     def wrapper(cls):
         if ext_type in _ext_codes_to_class:
-            raise ValueError("Ext type 0x{:02x} already registered with class {:s}".format(ext_type, repr(_ext_classes[ext_type])))
+            raise ValueError("Ext type 0x{:02x} already registered with class {:s}".format(ext_type, repr(_ext_codes_to_class[ext_type])))
         elif cls in _ext_classes_to_code:
             raise ValueError("Class {:s} already registered with Ext type 0x{:02x}".format(repr(cls), ext_type))
 
@@ -820,7 +820,7 @@ def _unpack_ext(code, fp, options):
         try:
             return _ext_codes_to_class[ext_type].unpackb(ext_data)
         except AttributeError:
-            raise NotImplementedError("Ext serializable class {:s} is missing implementation of unpackb()".format(repr(_ext_classes[ext_type])))
+            raise NotImplementedError("Ext serializable class {:s} is missing implementation of unpackb()".format(repr(_ext_codes_to_class[ext_type])))
 
     # Timestamp extension
     if ext_type == -1:

--- a/umsgpack.py
+++ b/umsgpack.py
@@ -140,7 +140,8 @@ class InvalidString(bytes):
 # Ext Serializable Decorator
 ##############################################################################
 
-_ext_classes = {}
+_ext_classes_to_code = {}
+_ext_codes_to_class = {}
 
 
 def ext_serializable(ext_type):
@@ -159,13 +160,13 @@ def ext_serializable(ext_type):
             Ext type or class already registered.
     """
     def wrapper(cls):
-        if ext_type in _ext_classes:
+        if ext_type in _ext_codes_to_class:
             raise ValueError("Ext type 0x{:02x} already registered with class {:s}".format(ext_type, repr(_ext_classes[ext_type])))
-        elif cls in _ext_classes:
+        elif cls in _ext_classes_to_code:
             raise ValueError("Class {:s} already registered with Ext type 0x{:02x}".format(repr(cls), ext_type))
 
-        _ext_classes[ext_type] = cls
-        _ext_classes[cls] = ext_type
+        _ext_codes_to_class[ext_type] = cls
+        _ext_classes_to_code[cls] = ext_type
 
         return cls
 
@@ -472,11 +473,19 @@ def _pack2(obj, fp, **options):
         _pack_nil(obj, fp, options)
     elif ext_handlers and obj.__class__ in ext_handlers:
         _pack_ext(ext_handlers[obj.__class__](obj), fp, options)
-    elif obj.__class__ in _ext_classes:
+    elif obj.__class__ in _ext_classes_to_code:
         try:
-            _pack_ext(Ext(_ext_classes[obj.__class__], obj.packb()), fp, options)
+            _pack_ext(Ext(_ext_classes_to_code[obj.__class__], obj.packb()), fp, options)
         except AttributeError:
             raise NotImplementedError("Ext serializable class {:s} is missing implementation of packb()".format(repr(obj.__class__)))
+    elif isinstance(obj, tuple(_ext_classes_to_code)):
+        for cls in _ext_classes_to_code:
+            if isinstance(obj, cls):
+                try:
+                    _pack_ext(Ext(_ext_classes_to_code[cls], obj.packb()), fp, options)
+                    break
+                except AttributeError:
+                    raise NotImplementedError("Ext serializable class {:s} is missing implementation of packb()".format(repr(cls)))
     elif isinstance(obj, bool):
         _pack_boolean(obj, fp, options)
     elif isinstance(obj, (int, long)):
@@ -549,11 +558,19 @@ def _pack3(obj, fp, **options):
         _pack_nil(obj, fp, options)
     elif ext_handlers and obj.__class__ in ext_handlers:
         _pack_ext(ext_handlers[obj.__class__](obj), fp, options)
-    elif obj.__class__ in _ext_classes:
+    elif obj.__class__ in _ext_classes_to_code:
         try:
-            _pack_ext(Ext(_ext_classes[obj.__class__], obj.packb()), fp, options)
+            _pack_ext(Ext(_ext_classes_to_code[obj.__class__], obj.packb()), fp, options)
         except AttributeError:
             raise NotImplementedError("Ext serializable class {:s} is missing implementation of packb()".format(repr(obj.__class__)))
+    elif isinstance(obj, tuple(_ext_classes_to_code)):
+        for cls in _ext_classes_to_code:
+            if isinstance(obj, cls):
+                try:
+                    _pack_ext(Ext(_ext_classes_to_code[cls], obj.packb()), fp, options)
+                    break
+                except AttributeError:
+                    raise NotImplementedError("Ext serializable class {:s} is missing implementation of packb()".format(repr(cls)))
     elif isinstance(obj, bool):
         _pack_boolean(obj, fp, options)
     elif isinstance(obj, int):
@@ -799,9 +816,9 @@ def _unpack_ext(code, fp, options):
         return ext_handlers[ext_type](Ext(ext_type, ext_data))
 
     # Unpack with ext classes, if type is registered
-    if ext_type in _ext_classes:
+    if ext_type in _ext_codes_to_class:
         try:
-            return _ext_classes[ext_type].unpackb(ext_data)
+            return _ext_codes_to_class[ext_type].unpackb(ext_data)
         except AttributeError:
             raise NotImplementedError("Ext serializable class {:s} is missing implementation of unpackb()".format(repr(_ext_classes[ext_type])))
 


### PR DESCRIPTION
A small breaking example on the old version should be something like:

```python
from abc import abstractmethod
from importlib import import_module
from typing import Any, Tuple

from umsgpack import ext_serializable, packb, unpackb


@ext_serializable(0x00)
class BaseMessage:
    def __new__(cls, protocol_ver: int, *args, **kwargs):
        if cls is BaseMessage:
            module = import_module(f'.v{protocol_ver:02}', 'protocol')
            return module.Message(protocol_ver, *args, **kwargs)  # type: ignore
        return super().__new__(cls)

    @property
    @abstractmethod
    def _data(self) -> Tuple[Any, ...]:
        raise NotImplementedError()

    def packb(self) -> bytes:
        return packb(self._data)

    @staticmethod
    def unpackb(data) -> 'BaseMessage':
        protocol_ver, *rest = unpackb(data)
        module = import_module(f'.v{protocol_ver:02}', 'protocol')
        return module.Message(protocol_ver, *rest)  # type: ignore
```

The intent of this one in particular is to be able to upgrade a messaging protocol cleanly, but it's admittedly more complicated than I would expect the average object scheme to do.

~~I believe~~ this is true for any objects that want to inherit without getting a new object code, ~~but I'm not entirely sure.~~

In either case, it's probably a good idea to keep those two mappings separate.