### PR TITLE
setup.cfg: Replace dash-separated options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
Recent versions of setuptools report that options with names separated
by a dash (e.g. 'home-page') are deprecated and support will be
removed in later versions.