### PR TITLE
fix hex formatting of Ext objects

### DIFF
--- a/umsgpack.py
+++ b/umsgpack.py
@@ -128,7 +128,7 @@ class Ext(object):
         String representation of this Ext object.
         """
         s = "Ext Object (Type: {:d}, Data: ".format(self.type)
-        s += " ".join(["0x{:02}".format(ord(self.data[i:i + 1]))
+        s += " ".join(["0x{:02x}".format(ord(self.data[i:i + 1]))
                        for i in xrange(min(len(self.data), 8))])
         if len(self.data) > 8:
             s += " ..."


### PR DESCRIPTION
The string representation of Ext objects claims to be numbers in hexadecimal, but they are formatted as decimals instead. This confused me quite a bit when I started investigating a particular protocol implementation.